### PR TITLE
feat: add support for evaluating all open MRs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-run::cli:
+scm-engine::evaluate:
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/golang:1.22.3
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,18 @@
-scm-engine::evaluate:
+# NOTE: This is integration testing file, its not meant for production usage
+#       The README has a production example
+
+scm-engine::evaluate::on-change:
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/golang:1.22.3
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   script:
     - go mod tidy
     - go run ./cmd/scm-engine/ evaluate
+
+scm-engine::evaluate::on-schedule:
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/golang:1.22.3
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - go mod tidy
+    - go run ./cmd/scm-engine/ evaluate all

--- a/.scm-engine.example.yml
+++ b/.scm-engine.example.yml
@@ -2,20 +2,44 @@
 
 actions:
   - name: Warn that the ticket if older than 30 days
-    if: merge_request.state != "closed" && merge_request.time_since_last_commit > duration("30d") && not merge_request.has_label("do-not-close")
+    if: |
+      // ignore MRs already closed
+      merge_request.state != "closed"
+      // if last commit happened more than 30 days ago
+      && merge_request.time_since_last_commit > duration("30d")
+      // but still less than 45 days ago (where we close the MR)
+      && merge_request.time_since_last_commit < duration("45d")
+      // and the label to disable this feature is not on the MR
+      && not merge_request.has_label("do-not-close")
     then:
       - action: comment
-        message: "Hey, this MR is old, we will close it in 15 days if no activity has happened. If you want to disable this behavior, add the label 'do-not-close' on the MR."
+        message: |
+          Hello!
+
+          This Merge Request have not seen any commit activity for 30 days. In an effort to keep our project clean we will automatically close the Merge request after 45 days.
+
+          You can add the "do-not-close" label to the Merge Request to disable this behavior.
 
   - name: Close ticket if older than 45 days
-    if: merge_request.state != "closed" && merge_request.time_since_last_commit > duration("45d") && not merge_request.has_label("do-not-close")
+    if: |
+      merge_request.state != "closed"
+      && merge_request.time_since_last_commit > duration("45d")
+      && not merge_request.has_label("do-not-close")
     then:
       - action: close
       - action: comment
-        message: "As promised, we're closing the MR due to inactivity, bye bye"
+        message: |
+          Hello!
+
+          This Merge Request have not seen any commit activity for 45 days. In an effort to keep our project clean we will automatically close the Merge request.
+
+          You can add the "do-not-close" label to the Merge Request to disable this behavior.
 
   - name: Approve MR if the 'break-glass-approve' label is configured
-    if: merge_request.state != "closed" && not merge_request.approved && merge_request.has_label("break-glass-approve")
+    if: |
+      merge_request.state != "closed"
+      && not merge_request.approved
+      && merge_request.has_label("break-glass-approve")
     then:
       - action: approve
       - action: comment

--- a/README.md
+++ b/README.md
@@ -119,12 +119,19 @@ Using scm-engine within a GitLab CI pipeline is straight forward.
 1. Setup a CI job using the `scm-engine` Docker image that will run when a pipeline is created from a Merge Request Event.
 
     ```yaml
-    scm-engine:
+    scm-engine::evaluate::on-merge-request-event:
       image: ghcr.io/jippi/scm-engine:latest
       rules:
         - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
       script:
         - scm-engine evaluate
+
+    scm-engine::evaluate::on-schedule:
+      image: ghcr.io/jippi/scm-engine:latest
+      rules:
+        - if: $CI_PIPELINE_SOURCE == "schedule"
+      script:
+        - scm-engine evaluate all
     ```
 
 1. Done! Every Merge Request change should now re-run scm-engine and apply your label rules

--- a/cmd/cmd_evaluate.go
+++ b/cmd/cmd_evaluate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jippi/scm-engine/pkg/config"
+	"github.com/jippi/scm-engine/pkg/scm"
 	"github.com/jippi/scm-engine/pkg/scm/gitlab"
 	"github.com/jippi/scm-engine/pkg/state"
 	"github.com/urfave/cli/v2"
@@ -23,6 +24,19 @@ func Evaluate(cCtx *cli.Context) error {
 	}
 
 	switch {
+	// If first arg is 'all' we will find all opened MRs and apply the rules to them
+	case cCtx.Args().First() == "all":
+		res, err := client.MergeRequests().List(ctx, &scm.ListMergeRequestsOptions{State: "opened", First: 100})
+		if err != nil {
+			return err
+		}
+
+		for _, mr := range res {
+			if err := ProcessMR(ctx, client, cfg, mr.ID); err != nil {
+				return err
+			}
+		}
+
 	// If the flag is set, use that for evaluation
 	case cCtx.String(FlagMergeRequestID) != "":
 		return ProcessMR(ctx, client, cfg, cCtx.String(FlagMergeRequestID))
@@ -37,7 +51,7 @@ func Evaluate(cCtx *cli.Context) error {
 				return err
 			}
 		}
-
-		return nil
 	}
+
+	return nil
 }

--- a/pkg/scm/interfaces.go
+++ b/pkg/scm/interfaces.go
@@ -19,6 +19,7 @@ type LabelClient interface {
 
 type MergeRequestClient interface {
 	Update(ctx context.Context, opt *UpdateMergeRequestOptions) (*Response, error)
+	List(ctx context.Context, options *ListMergeRequestsOptions) ([]ListMergeRequest, error)
 }
 
 type EvalContext interface {

--- a/pkg/scm/types.go
+++ b/pkg/scm/types.go
@@ -94,6 +94,16 @@ type ListOptions struct {
 	Sort string `json:"sort,omitempty" url:"sort,omitempty"`
 }
 
+type ListMergeRequestsOptions struct {
+	ListOptions
+	State string
+	First int
+}
+
+type ListMergeRequest struct {
+	ID string `expr:"id" graphql:"id"`
+}
+
 // Response is a GitLab API response. This wraps the standard http.Response
 // returned from GitLab and provides convenient access to things like
 // pagination links.

--- a/schema/gitlab.go
+++ b/schema/gitlab.go
@@ -67,7 +67,12 @@ func main() {
 func nest(props []*Property) {
 	for _, field := range props {
 		if field.IsCustomType {
-			for _, nested := range PropMap[field.Type].Attributes {
+			attr, ok := PropMap[field.Type]
+			if !ok {
+				continue
+			}
+
+			for _, nested := range attr.Attributes {
 				field.AddAttribute(&Property{
 					Name:         nested.Name,
 					Description:  nested.Description,
@@ -148,6 +153,8 @@ func mutateHook(b *modelgen.ModelBuild) *modelgen.ModelBuild {
 			Type:        modelName,
 			Description: model.Description,
 		}
+
+		fmt.Println("model", modelProperty.Name)
 
 		for _, field := range model.Fields {
 			tags, err := structtag.Parse(field.Tag)

--- a/schema/gitlab.schema.graphqls
+++ b/schema/gitlab.schema.graphqls
@@ -21,6 +21,7 @@ scalar Time
 # Add time.Duration support
 scalar Duration
 
+
 type Context {
   "The project the Merge Request belongs to"
   Project: ContextProject @graphql(key: "project(fullPath: $project_id)")
@@ -30,6 +31,37 @@ type Context {
 
   "Information about the Merge Request"
   MergeRequest: ContextMergeRequest @generated
+}
+
+enum MergeRequestState {
+  all
+  closed
+  locked
+  merged
+  opened
+}
+
+input ListMergeRequestsQueryInput {
+  project_id: ID!
+  state: MergeRequestState! = "opened"
+  first: Int! = 100
+}
+
+type ListMergeRequestsQuery {
+  "The project the Merge Request belongs to"
+  Project: ListMergeRequestsProject @graphql(key: "project(fullPath: $project_id)")
+}
+
+type ListMergeRequestsProject {
+  MergeRequests: ListMergeRequestsProjectMergeRequestNodes @graphql(key: "mergeRequests(state: $state, first: $first)") @internal
+}
+
+type ListMergeRequestsProjectMergeRequestNodes {
+  Nodes: [ListMergeRequestsProjectMergeRequest!]
+}
+
+type ListMergeRequestsProjectMergeRequest {
+  ID: String! @graphql(key: "iid") @internal
 }
 
 type ContextProject {


### PR DESCRIPTION
By running `scm-engine evaluate all` it will now evaluate the first 100 MRs against the ruleset.

Support for pagination (beyond 100) will come later.