### PR TITLE
feat: implement CI pipeline status reporting when evaluating MR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,3 +68,25 @@ jobs:
       - uses: github/codeql-action/autobuild@v3
 
       - uses: github/codeql-action/analyze@v3
+
+  # ------------------------------
+
+  semgrep:
+    runs-on: ubuntu-latest
+    name: semgrep
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: dgryski/semgrep-go
+          path: rules
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: semgrep
+        run: semgrep scan --error --enable-nosem -f ./rules .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,28 +40,6 @@ jobs:
 
   # ------------------------------
 
-  semgrep:
-    runs-on: ubuntu-latest
-    name: semgrep
-    container:
-      image: returntocorp/semgrep
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/checkout@v4
-        with:
-          repository: dgryski/semgrep-go
-          path: rules
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: semgrep
-        run: semgrep scan --error --enable-nosem -f ./rules .
-
-  # ------------------------------
-
   gitleaks:
     runs-on: ubuntu-latest
     name: gitleaks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./scm-engine -h
 
       - name: Test scm-engine against test GitLab project
-        run: ./scm-engine evaluate 1
+        run: ./scm-engine evaluate --all
         env:
           SCM_ENGINE_TOKEN: "${{ secrets.GITLAB_INTEGRATION_TEST_API_TOKEN }}"
           SCM_ENGINE_CONFIG_FILE: ".scm-engine.example.yml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./scm-engine -h
 
       - name: Test scm-engine against test GitLab project
-        run: ./scm-engine evaluate --all
+        run: ./scm-engine evaluate all
         env:
           SCM_ENGINE_TOKEN: "${{ secrets.GITLAB_INTEGRATION_TEST_API_TOKEN }}"
           SCM_ENGINE_CONFIG_FILE: ".scm-engine.example.yml"

--- a/cmd/conventions.go
+++ b/cmd/conventions.go
@@ -5,6 +5,8 @@ const (
 	FlagConfigFile     = "config"
 	FlagDryRun         = "dry-run"
 	FlagMergeRequestID = "id"
+	FlagUpdatePipeline = "update-pipeline"
+	FlagCommitSHA      = "commit"
 	FlagSCMBaseURL     = "base-url"
 	FlagSCMProject     = "project"
 	FlagServerListen   = "listen"

--- a/docs/commands/evaluate.md
+++ b/docs/commands/evaluate.md
@@ -12,12 +12,14 @@ NAME:
    scm-engine evaluate - Evaluate a Merge Request
 
 USAGE:
-   scm-engine evaluate [command options] [id, id, ...]
+   scm-engine evaluate [command options] [mr_id, mr_id, ...]
 
 OPTIONS:
-   --project value                                                GitLab project (example: 'gitlab-org/gitlab') [$GITLAB_PROJECT, $CI_PROJECT_PATH]
-   --id value, --merge-request-id value, --pull-request-id value  The pull/merge to process, if not provided as a CLI flag [$CI_MERGE_REQUEST_IID]
-   --help, -h                                                     show help
+   --project value    GitLab project (example: 'gitlab-org/gitlab') [$GITLAB_PROJECT, $CI_PROJECT_PATH]
+   --id value         The pull/merge ID to process, if not provided as a CLI flag [$CI_MERGE_REQUEST_IID]
+   --commit value     The git commit sha [$CI_COMMIT_SHA]
+   --update-pipeline  Update the CI pipeline status with progress (default: true) [$SCM_ENGINE_SKIP_PIPELINE]
+   --help, -h         show help
 
 GLOBAL OPTIONS:
    --config value     Path to the scm-engine config file (default: ".scm-engine.yml") [$SCM_ENGINE_CONFIG_FILE]

--- a/docs/commands/evaluate.md
+++ b/docs/commands/evaluate.md
@@ -18,7 +18,7 @@ OPTIONS:
    --project value    GitLab project (example: 'gitlab-org/gitlab') [$GITLAB_PROJECT, $CI_PROJECT_PATH]
    --id value         The pull/merge ID to process, if not provided as a CLI flag [$CI_MERGE_REQUEST_IID]
    --commit value     The git commit sha [$CI_COMMIT_SHA]
-   --update-pipeline  Update the CI pipeline status with progress (default: true) [$SCM_ENGINE_SKIP_PIPELINE]
+   --update-pipeline  Update the CI pipeline status with progress (default: true) [$SCM_ENGINE_UPDATE_PIPELINE]
    --help, -h         show help
 
 GLOBAL OPTIONS:

--- a/docs/commands/server.md
+++ b/docs/commands/server.md
@@ -25,7 +25,8 @@ USAGE:
 
 OPTIONS:
    --webhook-secret value  Used to validate received payloads. Sent with the request in the X-Gitlab-Token HTTP header [$SCM_ENGINE_WEBHOOK_SECRET]
-   --listen value          Port the HTTP server should listen on (default: "0.0.0.0:3000") [$SCM_ENGINE_LISTEN]
+   --listen value          IP + Port that the HTTP server should listen on (default: "0.0.0.0:3000") [$SCM_ENGINE_LISTEN]
+   --update-pipeline       Update the CI pipeline status with progress (default: true) [$SCM_ENGINE_SKIP_PIPELINE]
    --help, -h              show help
 
 GLOBAL OPTIONS:

--- a/docs/commands/server.md
+++ b/docs/commands/server.md
@@ -26,7 +26,7 @@ USAGE:
 OPTIONS:
    --webhook-secret value  Used to validate received payloads. Sent with the request in the X-Gitlab-Token HTTP header [$SCM_ENGINE_WEBHOOK_SECRET]
    --listen value          IP + Port that the HTTP server should listen on (default: "0.0.0.0:3000") [$SCM_ENGINE_LISTEN]
-   --update-pipeline       Update the CI pipeline status with progress (default: true) [$SCM_ENGINE_SKIP_PIPELINE]
+   --update-pipeline       Update the CI pipeline status with progress (default: true) [$SCM_ENGINE_UPDATE_PIPELINE]
    --help, -h              show help
 
 GLOBAL OPTIONS:

--- a/docs/gitlab/setup.md
+++ b/docs/gitlab/setup.md
@@ -4,14 +4,14 @@
 
 Using `scm-engine` as a webhook server allows for richer feature set compared to [GitLab CI pipeline](#gitlab-ci-pipeline) mode
 
-- `+` Reacting to comments
-- `+` Access to webhook event data in scripts via `webhook_event.*` (see [server docs](../commands/server.md) for more information)
-- `+` A single `scm-engine` instance (and single token) for your GitLab project, group, or instance depending on where you configure the webhook.
-- `+` Each Project still have their own `.scm-engine.yml` file, it's downloaded via the API when the server is processing a webhook event.
-- `+` A single "bot" identity across your projects.
-- `+` Turn key once configured; if a project want to use `scm-engine` they just need to create the `.scm-engine.yml` file in their project.
-- `+` Real-time reactions to changes
-- `-` No intuitive access to [`evaluation` logs](../commands/evaluate.md) within GitLab (you can see them in the server logs or in the webhook failure log)
+- [X] Real-time reactions to changes.
+- [X] Reacting to comments.
+- [X] Access to webhook event data in scripts via `webhook_event.*` (see [server docs](../commands/server.md) for more information).
+- [X] A single `scm-engine` instance (and single token) for your GitLab project, group, or instance depending on where you configure the webhook.
+- [X] Each Project still have their own `.scm-engine.yml` file, it's downloaded via the API when the server is processing a webhook event.
+- [X] A single "bot" identity across your projects.
+- [X] Turn key once configured; if a project want to use `scm-engine` they just need to create the `.scm-engine.yml` file in their project.
+- [ ] No intuitive access to [`evaluation` logs](../commands/evaluate.md) within GitLab (you can see them in the server logs or in the webhook failure log).
 
 **Setup**:
 
@@ -22,11 +22,11 @@ Using `scm-engine` as a webhook server allows for richer feature set compared to
 
 Using `scm-engine` within a GitLab CI pipeline is straight forward - every time a CI pipeline runs, `scm-engine` will [evaluate](../commands/evaluate.md) the Merge Request.
 
-- `+` Simple & quick installation.
-- `+` Limited access token permissions.
-- `+` Easy access to [`evaluation` logs](../commands/evaluate.md) within the GitLab CI job.
-- `-` Can't react to comments; only works within a CI pipeline.
-- `-` Higher latency for reacting to changes depending on how fast CI jobs run (and where in the pipeline it runs).
+- [X] Simple & quick installation.
+- [X] Limited access token permissions.
+- [X] Easy access to [`evaluation` logs](../commands/evaluate.md) within the GitLab CI job.
+- [ ] Can't react to comments; only works within a CI pipeline.
+- [ ] Higher latency for reacting to changes depending on how fast CI jobs run (and where in the pipeline it runs).
 
 **Setup**:
 

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 				Name:      "evaluate",
 				Usage:     "Evaluate a Merge Request",
 				Args:      true,
-				ArgsUsage: " [id, id, ...]",
+				ArgsUsage: " [mr_id, mr_id, ...]",
 				Action:    cmd.Evaluate,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -92,14 +92,27 @@ func main() {
 						},
 					},
 					&cli.StringFlag{
-						Name:  cmd.FlagMergeRequestID,
-						Usage: "The pull/merge to process, if not provided as a CLI flag",
-						Aliases: []string{
-							"merge-request-id", // GitLab naming
-							"pull-request-id",  // GitHub naming
-						},
+						Name:     cmd.FlagMergeRequestID,
+						Usage:    "The pull/merge ID to process, if not provided as a CLI flag",
+						Required: true,
 						EnvVars: []string{
 							"CI_MERGE_REQUEST_IID", // GitLab CI
+						},
+					},
+					&cli.StringFlag{
+						Name:     cmd.FlagCommitSHA,
+						Usage:    "The git commit sha",
+						Required: true,
+						EnvVars: []string{
+							"CI_COMMIT_SHA", // GitLab CI
+						},
+					},
+					&cli.BoolFlag{
+						Name:  cmd.FlagUpdatePipeline,
+						Usage: "Update the CI pipeline status with progress",
+						Value: true,
+						EnvVars: []string{
+							"SCM_ENGINE_SKIP_PIPELINE",
 						},
 					},
 				},
@@ -122,6 +135,14 @@ func main() {
 						Value: "0.0.0.0:3000",
 						EnvVars: []string{
 							"SCM_ENGINE_LISTEN",
+						},
+					},
+					&cli.BoolFlag{
+						Name:  cmd.FlagUpdatePipeline,
+						Usage: "Update the CI pipeline status with progress",
+						Value: true,
+						EnvVars: []string{
+							"SCM_ENGINE_SKIP_PIPELINE",
 						},
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 			&cli.BoolFlag{
 				Name:  cmd.FlagDryRun,
 				Usage: "Dry run, don't actually _do_ actions, just print them",
+				Value: false,
 			},
 		},
 		Commands: []*cli.Command{
@@ -110,7 +111,7 @@ func main() {
 						Usage: "Update the CI pipeline status with progress",
 						Value: true,
 						EnvVars: []string{
-							"SCM_ENGINE_SKIP_PIPELINE",
+							"SCM_ENGINE_UPDATE_PIPELINE",
 						},
 					},
 				},
@@ -140,7 +141,7 @@ func main() {
 						Usage: "Update the CI pipeline status with progress",
 						Value: true,
 						EnvVars: []string{
-							"SCM_ENGINE_SKIP_PIPELINE",
+							"SCM_ENGINE_UPDATE_PIPELINE",
 						},
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -92,9 +92,8 @@ func main() {
 						},
 					},
 					&cli.StringFlag{
-						Name:     cmd.FlagMergeRequestID,
-						Usage:    "The pull/merge ID to process, if not provided as a CLI flag",
-						Required: true,
+						Name:  cmd.FlagMergeRequestID,
+						Usage: "The pull/merge ID to process, if not provided as a CLI flag",
 						EnvVars: []string{
 							"CI_MERGE_REQUEST_IID", // GitLab CI
 						},

--- a/main.go
+++ b/main.go
@@ -99,9 +99,8 @@ func main() {
 						},
 					},
 					&cli.StringFlag{
-						Name:     cmd.FlagCommitSHA,
-						Usage:    "The git commit sha",
-						Required: true,
+						Name:  cmd.FlagCommitSHA,
+						Usage: "The git commit sha",
 						EnvVars: []string{
 							"CI_COMMIT_SHA", // GitLab CI
 						},

--- a/pkg/scm/gitlab/client.go
+++ b/pkg/scm/gitlab/client.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jippi/scm-engine/pkg/scm"
+	"github.com/jippi/scm-engine/pkg/state"
 	go_gitlab "github.com/xanzy/go-gitlab"
 )
 
@@ -57,6 +58,50 @@ func (client *Client) EvalContext(ctx context.Context) (scm.EvalContext, error) 
 	}
 
 	return res, nil
+}
+
+// Start pipeline
+func (client *Client) Start(ctx context.Context) error {
+	if !state.ShouldUpdatePipeline(ctx) {
+		return nil
+	}
+
+	_, _, err := client.wrapped.Commits.SetCommitStatus(state.ProjectID(ctx), state.CommitSHA(ctx), &go_gitlab.SetCommitStatusOptions{
+		State:       go_gitlab.Running,
+		Name:        go_gitlab.Ptr("scm-engine"),
+		Description: go_gitlab.Ptr("Currently evaluating MR"),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stop pipeline
+func (client *Client) Stop(ctx context.Context, err error) error {
+	if !state.ShouldUpdatePipeline(ctx) {
+		return nil
+	}
+
+	status := go_gitlab.Success
+	message := "OK"
+
+	if err != nil {
+		status = go_gitlab.Failed
+		message = err.Error()
+	}
+
+	_, _, err = client.wrapped.Commits.SetCommitStatus(state.ProjectID(ctx), state.CommitSHA(ctx), &go_gitlab.SetCommitStatusOptions{
+		State:       status,
+		Name:        go_gitlab.Ptr("scm-engine"),
+		Description: go_gitlab.Ptr(message),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func graphqlBaseURL(inputURL *url.URL) string {

--- a/pkg/scm/gitlab/client.go
+++ b/pkg/scm/gitlab/client.go
@@ -71,11 +71,8 @@ func (client *Client) Start(ctx context.Context) error {
 		Name:        go_gitlab.Ptr("scm-engine"),
 		Description: go_gitlab.Ptr("Currently evaluating MR"),
 	})
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 // Stop pipeline
@@ -97,11 +94,8 @@ func (client *Client) Stop(ctx context.Context, err error) error {
 		Name:        go_gitlab.Ptr("scm-engine"),
 		Description: go_gitlab.Ptr(message),
 	})
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 func graphqlBaseURL(inputURL *url.URL) string {

--- a/pkg/scm/gitlab/client_merge_request.go
+++ b/pkg/scm/gitlab/client_merge_request.go
@@ -87,10 +87,19 @@ func (client *MergeRequestClient) List(ctx context.Context, options *scm.ListMer
 		return nil, err
 	}
 
-	hits := []scm.ListMergeRequest{}
-	for _, x := range result.Project.MergeRequests.Nodes {
-		hits = append(hits, scm.ListMergeRequest{ID: x.ID})
+	results := []scm.ListMergeRequest{}
+
+	for _, mergeRequest := range result.Project.MergeRequests.Nodes {
+		// If there are no DiffHeadSha; there are no commits on the MR; so don't process it
+		if mergeRequest.DiffHeadSha == nil {
+			continue
+		}
+
+		results = append(results, scm.ListMergeRequest{
+			ID:  mergeRequest.ID,
+			SHA: *mergeRequest.DiffHeadSha,
+		})
 	}
 
-	return hits, nil
+	return results, nil
 }

--- a/pkg/scm/interfaces.go
+++ b/pkg/scm/interfaces.go
@@ -10,6 +10,8 @@ type Client interface {
 	MergeRequests() MergeRequestClient
 	EvalContext(ctx context.Context) (EvalContext, error)
 	ApplyStep(ctx context.Context, update *UpdateMergeRequestOptions, step EvaluationActionStep) error
+	Start(ctx context.Context) error
+	Stop(ctx context.Context, err error) error
 }
 
 type LabelClient interface {

--- a/pkg/scm/types.go
+++ b/pkg/scm/types.go
@@ -101,7 +101,8 @@ type ListMergeRequestsOptions struct {
 }
 
 type ListMergeRequest struct {
-	ID string `expr:"id" graphql:"id"`
+	ID  string `expr:"id"  graphql:"id"`
+	SHA string `expr:"sha" graphql:"sha"`
 }
 
 // Response is a GitLab API response. This wraps the standard http.Response

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -14,30 +14,49 @@ const (
 	projectID contextKey = iota
 	dryRun
 	mergeRequestID
+	commitSha
+	updatePipeline
 )
-
-func NewContext(project, mr string) context.Context {
-	ctx := context.Background()
-	ctx = ContextWithProjectID(ctx, project)
-	ctx = ContextWithMergeRequestID(ctx, mr)
-
-	return ctx
-}
 
 func ProjectID(ctx context.Context) string {
 	return ctx.Value(projectID).(string) //nolint:forcetypeassert
 }
 
-func ContextWithProjectID(ctx context.Context, value string) context.Context {
+func CommitSHA(ctx context.Context) string {
+	return ctx.Value(commitSha).(string) //nolint:forcetypeassert
+}
+
+func WithProjectID(ctx context.Context, value string) context.Context {
 	ctx = slogctx.With(ctx, slog.String("project_id", value))
 	ctx = context.WithValue(ctx, projectID, value)
 
 	return ctx
 }
 
-func ContextWithDryRun(ctx context.Context, dry bool) context.Context {
+func WithDryRun(ctx context.Context, dry bool) context.Context {
 	ctx = slogctx.With(ctx, slog.Bool("dry_run", dry))
 	ctx = context.WithValue(ctx, dryRun, dry)
+
+	return ctx
+}
+
+func WithUpdatePipeline(ctx context.Context, update bool) context.Context {
+	ctx = slogctx.With(ctx, slog.Bool("update_pipeline", update))
+	ctx = context.WithValue(ctx, updatePipeline, update)
+
+	return ctx
+}
+
+func WithCommitSHA(ctx context.Context, sha string) context.Context {
+	ctx = slogctx.With(ctx, slog.String("git_commit_sha", sha))
+	ctx = context.WithValue(ctx, commitSha, sha)
+
+	return ctx
+}
+
+func ContextWithMergeRequestID(ctx context.Context, id string) context.Context {
+	ctx = slogctx.With(ctx, "merge_request_id", id)
+	ctx = context.WithValue(ctx, mergeRequestID, id)
 
 	return ctx
 }
@@ -46,11 +65,8 @@ func IsDryRun(ctx context.Context) bool {
 	return ctx.Value(dryRun).(bool) //nolint:forcetypeassert
 }
 
-func ContextWithMergeRequestID(ctx context.Context, id string) context.Context {
-	ctx = slogctx.With(ctx, "merge_request_id", id)
-	ctx = context.WithValue(ctx, mergeRequestID, id)
-
-	return ctx
+func ShouldUpdatePipeline(ctx context.Context) bool {
+	return ctx.Value(updatePipeline).(bool) //nolint:forcetypeassert
 }
 
 func MergeRequestID(ctx context.Context) string {

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -66,7 +66,7 @@ func IsDryRun(ctx context.Context) bool {
 }
 
 func ShouldUpdatePipeline(ctx context.Context) bool {
-	return ctx.Value(updatePipeline).(bool) //nolint:forcetypeassert
+	return !IsDryRun(ctx) && ctx.Value(updatePipeline).(bool) //nolint:forcetypeassert
 }
 
 func MergeRequestID(ctx context.Context) string {

--- a/schema/gitlab.schema.graphqls
+++ b/schema/gitlab.schema.graphqls
@@ -38,7 +38,7 @@ type Context {
   CurrentUser: ContextUser!
 
   "Information about the event that triggered the evaluation. Empty when not using webhook server."
-  WebhookEvent: Any @generated
+  WebhookEvent: Any @generated @expr(key: "webhook_event")
 }
 
 enum MergeRequestState {
@@ -98,7 +98,8 @@ type ListMergeRequestsProjectMergeRequestNodes {
 }
 
 type ListMergeRequestsProjectMergeRequest {
-  ID: String! @graphql(key: "iid") @internal
+  ID:          String! @graphql(key: "iid")         @internal
+  DiffHeadSha: String  @graphql(key: "diffHeadSha") @internal
 }
 
 # https://docs.gitlab.com/ee/api/graphql/reference/#project
@@ -135,9 +136,9 @@ type ContextProject {
   "Labels available on this project"
   Labels: [ContextLabel!] @generated
 
-  ResponseLabels: ContextLabelNode @internal @graphql(key: "labels(first: 200)")
-  MergeRequest: ContextMergeRequest @internal @graphql(key: "mergeRequest(iid: $mr_id)")
-  ResponseGroup: ContextGroup @internal @graphql(key: "group")
+  ResponseLabels: ContextLabelNode    @internal @graphql(key: "labels(first: 200)")
+  MergeRequest:   ContextMergeRequest @internal @graphql(key: "mergeRequest(iid: $mr_id)")
+  ResponseGroup:  ContextGroup        @internal @graphql(key: "group")
 }
 
 # https://docs.gitlab.com/ee/api/graphql/reference/#group


### PR DESCRIPTION
### Breaking change:

#### `--commit` / `$CI_COMMIT_SHA` variable

`scm-engine evaluate` now requires `--commit` (or env `CI_COMMIT_SHA`) to work. 

The `CI_COMMIT_SHA` variable is provided in GitLab CI pipelines automatically; so hopefully shouldn't break anything.

#### `--update-pipeline` / `$SCM_ENGINE_UPDATE_PIPELINE` (default: `true`)

Projects without CI pipelines might fail due to lack of CI pipeline API; other projects should now see an external CI pipeline status from `scm-engine` showing success/failure + relevant error message when `scm-engine` is processing an MR