### PR TITLE
feat: add configuration allowing scm-engine to ignore specific users activity when calculating inactivity on a MR/PR

### DIFF
--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -28,6 +28,9 @@ func getClient(ctx context.Context) (scm.Client, error) {
 }
 
 func ProcessMR(ctx context.Context, client scm.Client, cfg *config.Config, event any) (err error) {
+	// Write the config to context so we can pull it out later
+	ctx = config.WithConfig(ctx, cfg)
+
 	// Stop the pipeline when we leave this func
 	defer func() {
 		if stopErr := client.Stop(ctx, err); stopErr != nil {
@@ -61,6 +64,9 @@ func ProcessMR(ctx context.Context, client scm.Client, cfg *config.Config, event
 	}
 
 	evalContext.SetWebhookEvent(event)
+	// Add our "ctx" to evalContext so Expr-Lang functions can reference them
+	// when they need to read our "cfg"
+	evalContext.SetContext(ctx)
 
 	slogctx.Info(ctx, "Evaluating context")
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,30 @@ The default configuration filename is `.scm-engine.yml`, either in current worki
 
 The file path can be changed via `--config` CLI flag and `#!css $SCM_ENGINE_CONFIG_FILE` environment variable.
 
+## `ignore_activity_from` {#actions data-toc-label="ignore_activity_from"}
+
+!!! question "What are activity?"
+
+  SCM-Engine defines activity as comments, reviews, commits, adding/removing labels and similar.
+
+  *Generally*, `activity` is what you see in the Merge/Pull Request `timeline` in the browser UI.
+
+Configure what users that should be ignored when considering activity on a Merge Request
+
+### `ignore_activity_from.bots` {#actions data-toc-label="bots"}
+
+Should `bot` users be ignored when considering activity? Default: `false`
+
+### `ignore_activity_from.usernames[]` {#actions data-toc-label="usernames"}
+
+A list of usernames that should be ignored when considering user activity. Default: `[]`
+
+### `ignore_activity_from.emails[]` {#actions data-toc-label="emails"}
+
+A list of emails that should be ignored when considering user activity. Default: `[]`
+
+**NOTE:** If a user do not have a public email configured on their profile, that users activity will never match this rule.
+
 ## `actions[]` {#actions data-toc-label="actions"}
 
 !!! question "What are actions?"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,9 +6,9 @@ The file path can be changed via `--config` CLI flag and `#!css $SCM_ENGINE_CONF
 
 ## `ignore_activity_from` {#actions data-toc-label="ignore_activity_from"}
 
-!!! question "What are activity?"
+!!! question "What is 'activity'?"
 
-  SCM-Engine defines activity as comments, reviews, commits, adding/removing labels and similar.
+  SCM-Engine defines activity as comments, reviews, commits, adding/removing labels and similar actions made on a change request.
 
   *Generally*, `activity` is what you see in the Merge/Pull Request `timeline` in the browser UI.
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/lmittmann/tint v1.0.5
 	github.com/muesli/termenv v0.15.2
 	github.com/samber/slog-multi v1.2.0
+	github.com/stretchr/testify v1.9.0
 	github.com/teacat/noire v1.1.0
 	github.com/urfave/cli/v2 v2.27.4
 	github.com/vektah/gqlparser/v2 v2.5.16
@@ -40,6 +41,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/samber/lo v1.38.1 // indirect

--- a/pkg/config/action.go
+++ b/pkg/config/action.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/patcher"
 	"github.com/expr-lang/expr/vm"
 	"github.com/jippi/scm-engine/pkg/scm"
 	"github.com/jippi/scm-engine/pkg/stdlib"
@@ -47,6 +48,7 @@ func (p *Action) initialize(evalContext scm.EvalContext) (*vm.Program, error) {
 	opts = append(opts, expr.Env(evalContext))
 	opts = append(opts, stdlib.FunctionRenamer)
 	opts = append(opts, stdlib.Functions...)
+	opts = append(opts, expr.Patch(patcher.WithContext{Name: "ctx"}))
 
 	return expr.Compile(p.If, opts...)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,14 +9,15 @@ import (
 )
 
 type Config struct {
-	Labels  Labels  `yaml:"label"`
-	Actions Actions `yaml:"actions"`
+	Labels             Labels             `yaml:"label"`
+	Actions            Actions            `yaml:"actions"`
+	IgnoreActivityFrom IgnoreActivityFrom `yaml:"ignore_activity_from"`
 }
 
 func (c Config) Evaluate(ctx context.Context, evalContext scm.EvalContext) ([]scm.EvaluationResult, []Action, error) {
 	slogctx.Info(ctx, "Evaluating labels")
 
-	labels, err := c.Labels.Evaluate(evalContext)
+	labels, err := c.Labels.Evaluate(ctx, evalContext)
 	if err != nil {
 		return nil, nil, fmt.Errorf("evaluation failed: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 func (c Config) Evaluate(ctx context.Context, evalContext scm.EvalContext) ([]scm.EvaluationResult, []Action, error) {
 	slogctx.Info(ctx, "Evaluating labels")
 
-	labels, err := c.Labels.Evaluate(ctx, evalContext)
+	labels, err := c.Labels.Evaluate(evalContext)
 	if err != nil {
 		return nil, nil, fmt.Errorf("evaluation failed: %w", err)
 	}

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"context"
+)
+
+type contextKey uint
+
+const (
+	configKey contextKey = iota
+)
+
+func WithConfig(ctx context.Context, config *Config) context.Context {
+	return context.WithValue(ctx, configKey, config)
+}
+
+func FromContext(ctx context.Context) *Config {
+	return ctx.Value(configKey).(*Config) //nolint:forcetypeassert
+}

--- a/pkg/config/ignore_activity_from.go
+++ b/pkg/config/ignore_activity_from.go
@@ -1,10 +1,6 @@
 package config
 
-type Actor struct {
-	Username string
-	Email    *string
-	IsBot    bool
-}
+import "github.com/jippi/scm-engine/pkg/scm"
 
 type IgnoreActivityFrom struct {
 	IsBot     bool     `yaml:"bots"`
@@ -12,7 +8,7 @@ type IgnoreActivityFrom struct {
 	Emails    []string `yaml:"emails"`
 }
 
-func (i IgnoreActivityFrom) Matches(actor Actor) bool {
+func (i IgnoreActivityFrom) Matches(actor scm.Actor) bool {
 	// If actor is bot and we ignore bot activity
 	if actor.IsBot && i.IsBot {
 		return true

--- a/pkg/config/ignore_activity_from.go
+++ b/pkg/config/ignore_activity_from.go
@@ -1,0 +1,42 @@
+package config
+
+type ActorMatcher struct {
+	Username string
+	Email    *string
+	IsBot    bool
+}
+
+type IgnoreActivityFrom struct {
+	IsBot     bool     `yaml:"bots"`
+	Usernames []string `yaml:"usernames"`
+	Emails    []string `yaml:"emails"`
+}
+
+func (i IgnoreActivityFrom) Matches(actor ActorMatcher) bool {
+	// If actor is bot and we ignore bot activity
+	if actor.IsBot && i.IsBot {
+		return true
+	}
+
+	// Check if the actor username is in the ignore list
+	for _, username := range i.Usernames {
+		if username == actor.Username {
+			return true
+		}
+	}
+
+	// If the actor don't have an email, we did not find a match, since
+	// our last check is on emails
+	if actor.Email == nil {
+		return false
+	}
+
+	// Check if the actor email matches any of the ignored ones
+	for _, email := range i.Emails {
+		if email == *actor.Email {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/config/ignore_activity_from.go
+++ b/pkg/config/ignore_activity_from.go
@@ -1,6 +1,6 @@
 package config
 
-type ActorMatcher struct {
+type Actor struct {
 	Username string
 	Email    *string
 	IsBot    bool
@@ -12,7 +12,7 @@ type IgnoreActivityFrom struct {
 	Emails    []string `yaml:"emails"`
 }
 
-func (i IgnoreActivityFrom) Matches(actor ActorMatcher) bool {
+func (i IgnoreActivityFrom) Matches(actor Actor) bool {
 	// If actor is bot and we ignore bot activity
 	if actor.IsBot && i.IsBot {
 		return true

--- a/pkg/config/ignore_activity_from_test.go
+++ b/pkg/config/ignore_activity_from_test.go
@@ -1,0 +1,90 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/jippi/scm-engine/pkg/config"
+	"github.com/jippi/scm-engine/pkg/scm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIgnoreActivityFrom_Matches(t *testing.T) {
+	t.Parallel()
+
+	defaultActor := scm.Actor{
+		Username: "jippi",
+		IsBot:    false,
+		Email:    scm.Ptr("jippi@scm-engine.example.com"),
+	}
+
+	botActor := scm.Actor{
+		Username: "scm-engine",
+		IsBot:    true,
+	}
+
+	tests := []struct {
+		name   string
+		actor  scm.Actor
+		fields config.IgnoreActivityFrom
+		want   bool
+	}{
+		{
+			name: "empty",
+			want: false,
+		},
+		{
+			name:  "default actor",
+			actor: defaultActor,
+		},
+		{
+			name:   "username: matching username",
+			actor:  defaultActor,
+			fields: config.IgnoreActivityFrom{Usernames: []string{"jippi"}},
+			want:   true,
+		},
+		{
+			name:   "username: partial matching",
+			actor:  defaultActor,
+			fields: config.IgnoreActivityFrom{Usernames: []string{"jippignu"}},
+			want:   false,
+		},
+		{
+			name:   "bot:, actor not a bot",
+			actor:  defaultActor,
+			fields: config.IgnoreActivityFrom{IsBot: true},
+			want:   false,
+		},
+		{
+			name:   "bot: ignore bot, actor is a bot",
+			actor:  botActor,
+			fields: config.IgnoreActivityFrom{IsBot: true},
+			want:   true,
+		},
+		{
+			name:   "ignore email, actor without email, should not match",
+			actor:  scm.Actor{Username: "jippi"},
+			fields: config.IgnoreActivityFrom{Emails: []string{"demo@example.com"}},
+			want:   false,
+		},
+		{
+			name:   "email: actor with different email, should not match",
+			actor:  defaultActor,
+			fields: config.IgnoreActivityFrom{Emails: []string{"demo@example.com"}},
+			want:   false,
+		},
+		{
+			name:   "email: actor with matching email",
+			actor:  defaultActor,
+			fields: config.IgnoreActivityFrom{Emails: []string{"jippi@scm-engine.example.com"}},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, tt.fields.Matches(tt.actor))
+		})
+	}
+}

--- a/pkg/config/label.go
+++ b/pkg/config/label.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -25,7 +24,7 @@ const (
 
 type Labels []*Label
 
-func (labels Labels) Evaluate(ctx context.Context, evalContext scm.EvalContext) ([]scm.EvaluationResult, error) {
+func (labels Labels) Evaluate(evalContext scm.EvalContext) ([]scm.EvaluationResult, error) {
 	var results []scm.EvaluationResult
 
 	// Evaluate labels

--- a/pkg/config/label.go
+++ b/pkg/config/label.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 
 	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/patcher"
 	"github.com/expr-lang/expr/vm"
 	"github.com/jippi/scm-engine/pkg/scm"
 	"github.com/jippi/scm-engine/pkg/stdlib"
@@ -23,7 +25,7 @@ const (
 
 type Labels []*Label
 
-func (labels Labels) Evaluate(evalContext scm.EvalContext) ([]scm.EvaluationResult, error) {
+func (labels Labels) Evaluate(ctx context.Context, evalContext scm.EvalContext) ([]scm.EvaluationResult, error) {
 	var results []scm.EvaluationResult
 
 	// Evaluate labels
@@ -155,6 +157,7 @@ func (p *Label) initialize(evalContext scm.EvalContext) error {
 		opts = append(opts, expr.Env(evalContext))
 		opts = append(opts, stdlib.FunctionRenamer)
 		opts = append(opts, stdlib.Functions...)
+		opts = append(opts, expr.Patch(patcher.WithContext{Name: "ctx"}))
 
 		p.scriptCompiled, err = expr.Compile(p.Script, opts...)
 		if err != nil {
@@ -170,6 +173,7 @@ func (p *Label) initialize(evalContext scm.EvalContext) error {
 		opts = append(opts, expr.Env(evalContext))
 		opts = append(opts, stdlib.FunctionRenamer)
 		opts = append(opts, stdlib.Functions...)
+		opts = append(opts, expr.Patch(patcher.WithContext{Name: "ctx"}))
 
 		p.skipIfCompiled, err = expr.Compile(p.SkipIf, opts...)
 		if err != nil {

--- a/pkg/scm/github/context.go
+++ b/pkg/scm/github/context.go
@@ -85,6 +85,10 @@ func (c *Context) SetWebhookEvent(in any) {
 	c.WebhookEvent = in
 }
 
+func (c *Context) SetContext(ctx context.Context) {
+	c.Context = ctx
+}
+
 func (c *Context) GetDescription() string {
 	return c.PullRequest.Body
 }

--- a/pkg/scm/gitlab/client_actioner.go
+++ b/pkg/scm/gitlab/client_actioner.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/patcher"
 	"github.com/jippi/scm-engine/pkg/scm"
 	"github.com/jippi/scm-engine/pkg/state"
 	"github.com/jippi/scm-engine/pkg/stdlib"
@@ -64,6 +65,7 @@ func (c *Client) ApplyStep(ctx context.Context, evalContext scm.EvalContext, upd
 			opts = append(opts, expr.Env(evalContext))
 			opts = append(opts, stdlib.FunctionRenamer)
 			opts = append(opts, stdlib.Functions...)
+			opts = append(opts, expr.Patch(patcher.WithContext{Name: "ctx"}))
 
 			program, err := expr.Compile(fmt.Sprintf("%s", script), opts...)
 			if err != nil {

--- a/pkg/scm/gitlab/context.go
+++ b/pkg/scm/gitlab/context.go
@@ -94,6 +94,10 @@ func (c *Context) SetWebhookEvent(in any) {
 	c.WebhookEvent = in
 }
 
+func (c *Context) SetContext(ctx context.Context) {
+	c.Context = ctx
+}
+
 func (c *Context) GetDescription() string {
 	if c.MergeRequest.Description == nil {
 		return ""

--- a/pkg/scm/gitlab/context_merge_request.go
+++ b/pkg/scm/gitlab/context_merge_request.go
@@ -65,7 +65,7 @@ func (e ContextMergeRequest) HasAnyActivityWithin(ctx context.Context, input any
 
 	for _, note := range e.Notes {
 		// Check if we should ignore the actor (user) activity
-		if cfg.IgnoreActivityFrom.Matches(note.Author.ToActorMatcher()) {
+		if cfg.IgnoreActivityFrom.Matches(note.Author.ToActor()) {
 			continue
 		}
 
@@ -92,7 +92,7 @@ func (e ContextMergeRequest) HasUserActivityWithin(ctx context.Context, input an
 
 	for _, note := range e.Notes {
 		// Check if we should ignore the actor (user) activity
-		if cfg.IgnoreActivityFrom.Matches(note.Author.ToActorMatcher()) {
+		if cfg.IgnoreActivityFrom.Matches(note.Author.ToActor()) {
 			continue
 		}
 

--- a/pkg/scm/gitlab/context_user.go
+++ b/pkg/scm/gitlab/context_user.go
@@ -2,8 +2,8 @@ package gitlab
 
 import "github.com/jippi/scm-engine/pkg/config"
 
-func (u ContextUser) ToActorMatcher() config.ActorMatcher {
-	return config.ActorMatcher{
+func (u ContextUser) ToActor() config.Actor {
+	return config.Actor{
 		Username: u.Username,
 		IsBot:    u.Bot,
 		Email:    u.PublicEmail,

--- a/pkg/scm/gitlab/context_user.go
+++ b/pkg/scm/gitlab/context_user.go
@@ -1,0 +1,11 @@
+package gitlab
+
+import "github.com/jippi/scm-engine/pkg/config"
+
+func (u ContextUser) ToActorMatcher() config.ActorMatcher {
+	return config.ActorMatcher{
+		Username: u.Username,
+		IsBot:    u.Bot,
+		Email:    u.PublicEmail,
+	}
+}

--- a/pkg/scm/gitlab/context_user.go
+++ b/pkg/scm/gitlab/context_user.go
@@ -1,9 +1,9 @@
 package gitlab
 
-import "github.com/jippi/scm-engine/pkg/config"
+import "github.com/jippi/scm-engine/pkg/scm"
 
-func (u ContextUser) ToActor() config.Actor {
-	return config.Actor{
+func (u ContextUser) ToActor() scm.Actor {
+	return scm.Actor{
 		Username: u.Username,
 		IsBot:    u.Bot,
 		Email:    u.PublicEmail,

--- a/pkg/scm/interfaces.go
+++ b/pkg/scm/interfaces.go
@@ -29,6 +29,7 @@ type MergeRequestClient interface {
 type EvalContext interface {
 	IsValid() bool
 	SetWebhookEvent(in any)
+	SetContext(ctx context.Context)
 	GetDescription() string
 }
 

--- a/pkg/scm/types.go
+++ b/pkg/scm/types.go
@@ -9,6 +9,12 @@ import (
 	"github.com/jippi/scm-engine/pkg/types"
 )
 
+type Actor struct {
+	Username string
+	Email    *string
+	IsBot    bool
+}
+
 // Label represents a GitLab label.
 //
 // GitLab API docs: https://docs.gitlab.com/ee/api/labels.html

--- a/schema/gitlab.schema.graphqls
+++ b/schema/gitlab.schema.graphqls
@@ -16,12 +16,15 @@ directive @expr(key: String!) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 directive @graphql(key: String!) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 # Add time.Time support
+# See: https://gqlgen.com/reference/scalars/#time
 scalar Time
 
 # Add time.Duration support
+# See: https://gqlgen.com/reference/scalars/#duration
 scalar Duration
 
 # Add 'any' type for Event
+# See: https://gqlgen.com/reference/scalars/#any
 scalar Any
 
 type Context {

--- a/schema/main.go
+++ b/schema/main.go
@@ -6,6 +6,7 @@ import (
 	"cmp"
 	_ "embed"
 	"fmt"
+	"go/types"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -243,6 +244,17 @@ func mutateHook(b *modelgen.ModelBuild) *modelgen.ModelBuild {
 
 			field.Tag = tags.String()
 		} // end fields loop
+
+		// Manually inject certain "expr env" fields that we can't reasonable create in graphql schema
+		if model.Name == "Context" {
+			model.Fields = append(model.Fields, &modelgen.Field{
+				Name:        "Context",
+				Description: "Go context used to pass around configuration (do not use directly!)",
+				GoName:      "Context",
+				Type:        types.NewNamed(types.NewTypeName(0, types.NewPackage("context", "context"), "Context", nil), nil, nil),
+				Tag:         `expr:"ctx" graphql:"-"`,
+			})
+		}
 
 		if strings.HasSuffix(model.Name, "Node") || model.Name == "Query" {
 			continue


### PR DESCRIPTION
Example configuration

```yaml
ignore_activity_from:
  bots: true
  usernames:
    - jippi
    - renovate-bot
    - scm-engine

```