### PR TITLE
Tweak MR activity logic

### DIFF
--- a/pkg/scm/gitlab/context_merge_request.go
+++ b/pkg/scm/gitlab/context_merge_request.go
@@ -62,6 +62,11 @@ func (e ContextMergeRequest) HasActivityWithin(ctx context.Context, input any) b
 	return e.HasAnyActivityWithin(ctx, input)
 }
 
+// updatedWithinDuration checks if the MR has been updated within the provided duration
+func (e ContextMergeRequest) updatedWithinDuration(dur time.Duration) bool {
+	return time.Now().Sub(e.UpdatedAt) < dur
+}
+
 // has_any_activity_within
 func (e ContextMergeRequest) HasAnyActivityWithin(ctx context.Context, input any) bool {
 	dur := stdlib.ToDuration(input)
@@ -69,7 +74,7 @@ func (e ContextMergeRequest) HasAnyActivityWithin(ctx context.Context, input any
 	cfg := config.FromContext(ctx)
 
 	// If the MR UpdatedAt has been updated within the duration, then we got some kind of activity
-	if now.Sub(e.UpdatedAt) < dur {
+	if e.updatedWithinDuration(dur) {
 		return true
 	}
 

--- a/pkg/scm/gitlab/context_merge_request.go
+++ b/pkg/scm/gitlab/context_merge_request.go
@@ -63,8 +63,8 @@ func (e ContextMergeRequest) HasActivityWithin(ctx context.Context, input any) b
 }
 
 // updatedWithinDuration checks if the MR has been updated within the provided duration
-func (e ContextMergeRequest) updatedWithinDuration(dur time.Duration) bool {
-	return time.Now().Sub(e.UpdatedAt) < dur
+func (e ContextMergeRequest) updatedWithinDuration(now time.Time, dur time.Duration) bool {
+	return now.Sub(e.UpdatedAt) < dur
 }
 
 // has_any_activity_within
@@ -74,7 +74,7 @@ func (e ContextMergeRequest) HasAnyActivityWithin(ctx context.Context, input any
 	cfg := config.FromContext(ctx)
 
 	// If the MR UpdatedAt has been updated within the duration, then we got some kind of activity
-	if e.updatedWithinDuration(dur) {
+	if e.updatedWithinDuration(now, dur) {
 		return true
 	}
 


### PR DESCRIPTION
* `any` activity now considers the MR `UpdatedAt` field
* Change the order of `any` detections to better match the likelihood of a positive match
* Document why `user` activity can not rely on the MR `UpdatedAt` field