### PR TITLE
Feat: add support for "include" config from other repos

### DIFF
--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/jippi/scm-engine/pkg/config"
 	"github.com/jippi/scm-engine/pkg/scm"
 	"github.com/jippi/scm-engine/pkg/scm/github"
@@ -112,6 +113,9 @@ func ProcessMR(ctx context.Context, client scm.Client, cfg *config.Config, event
 	if cfg == nil {
 		return errors.New("cfg==nil; this is unexpected an error, please report!")
 	}
+
+	spew.Dump(cfg.LoadIncludes(ctx, client))
+	panic("end")
 
 	// Allow changing the 'dry-run' mode via configuration file
 	if cfg.DryRun != nil && *cfg.DryRun != state.IsDryRun(ctx) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,9 +8,9 @@ The file path can be changed via `--config` CLI flag and `#!css $SCM_ENGINE_CONF
 
 !!! question "What is 'activity'?"
 
-  SCM-Engine defines activity as comments, reviews, commits, adding/removing labels and similar actions made on a change request.
+    SCM-Engine defines activity as comments, reviews, commits, adding/removing labels and similar actions made on a change request.
 
-  *Generally*, `activity` is what you see in the Merge/Pull Request `timeline` in the browser UI.
+    *Generally*, `activity` is what you see in the Merge/Pull Request `timeline` in the browser UI.
 
 Configure what users that should be ignored when considering activity on a Merge Request
 
@@ -27,6 +27,39 @@ A list of usernames that should be ignored when considering user activity. Defau
 A list of emails that should be ignored when considering user activity. Default: `[]`
 
 **NOTE:** If a user do not have a public email configured on their profile, that users activity will never match this rule.
+
+## `include[]` {#include data-toc-label="include"}
+
+!!! question "What are includes?"
+
+    `scm-engine` has support for importing some (or all) of its configuration from other repositories.
+
+!!! note "The `scm-engine` API token MUST be able to read the content of the referenced projects via the API"
+
+!!! abstract "Limitations and restrictions of remote included configuration files"
+
+    This is immensely useful if you want to share configuration between many projects, like a centralized `scm-engine-library` project with common patterns and configuration files.
+
+    * Only `actions` and `label` configurations keys are supported in included configuration files.
+    * Nested/Recursive includes are NOT support.
+    * Merging/overriding configurations are NOT supported; included configuration will always append to the existing configuration.
+    * All included files MUST exist and be valid; any missing file or invalid configuration will result in failure.
+    * `scm-engine` will read all files from a project in a single request where possible; up to 100 files are supported.
+    * `scm-engine` do NOT cache any remote configuration files; they are always read during evaluation cycle.
+
+### `include[].project` {#include.project data-toc-label="project"}
+
+The GitLab repository slug to read configuration files, like `example/project`.
+
+### `include[].ref` {#include.ref data-toc-label="ref"}
+
+Optional Git reference to read the configuration from; it can be a tag, branch, or commit SHA.
+
+If omitted, `HEAD` is used; meaning your default branch.
+
+### `include[].files` {#include.files data-toc-label="files"}
+
+The list of files to include from the project. The paths must be *relative* to the repository root, e.x. `label/some-config-file.yml`; NOT `/label/some-config-file.yml`
 
 ## `actions[]` {#actions data-toc-label="actions"}
 
@@ -62,11 +95,11 @@ The list of operations to take if the [`#!css action.if`](#actions.if) returned 
 
 This key controls what kind of action that should be taken.
 
-- `#!yaml approve` to approve the Merge Request.
-- `#!yaml unapprove` to approve the Merge Request.
-- `#!yaml close` to close the Merge Request.
-- `#!yaml reopen` to reopen the Merge Request.
-- `#!yaml comment` to add a comment to the Merge Request
+* `#!yaml approve` to approve the Merge Request.
+* `#!yaml unapprove` to approve the Merge Request.
+* `#!yaml close` to close the Merge Request.
+* `#!yaml reopen` to reopen the Merge Request.
+* `#!yaml comment` to add a comment to the Merge Request
 
       *Additional fields:*
 
@@ -78,9 +111,9 @@ This key controls what kind of action that should be taken.
           Hello world
       ```
 
-- `#!yaml lock_discussion` to prevent further discussions on the Merge Request.
-- `#!yaml unlock_discussion` to allow discussions on the Merge Request.
-- `#!yaml add_label` to add *an existing* label to the Merge Request
+* `#!yaml lock_discussion` to prevent further discussions on the Merge Request.
+* `#!yaml unlock_discussion` to allow discussions on the Merge Request.
+* `#!yaml add_label` to add *an existing* label to the Merge Request
 
       *Additional fields:*
 
@@ -91,7 +124,7 @@ This key controls what kind of action that should be taken.
         label: example
       ```
 
-- `#!yaml remove_label` to remove a label from the Merge Request
+* `#!yaml remove_label` to remove a label from the Merge Request
 
       *Additional fields:*
 
@@ -102,7 +135,7 @@ This key controls what kind of action that should be taken.
         label: example
       ```
 
-- `#!yaml update_description` updates the Merge Request Description
+* `#!yaml update_description` updates the Merge Request Description
 
       *Additional fields:*
 
@@ -129,11 +162,11 @@ These keys are shared between the [`#!yaml conditional`](#label.strategy-conditi
 
 SCM Engine supports two strategies for managing labels, each changes the behavior of the [`#!css script`](#label.script).
 
-- `#!yaml conditional` (default, if `#!css strategy` key is omitted), where you provide the `#!css name` of the label, and a [`#!css script`](#label.script) that returns a boolean for wether the label should be added to the Merge Request.
+* `#!yaml conditional` (default, if `#!css strategy` key is omitted), where you provide the `#!css name` of the label, and a [`#!css script`](#label.script) that returns a boolean for wether the label should be added to the Merge Request.
 
     The [`#!css script`](#label.script) must return a `#!yaml boolean` value, where `#!yaml true` mean `add the label` and `#!yaml false` mean `remove the label`.
 
-- `#!yaml generate`, where your `#!css script` generates the list of labels that should be added to the Merge Request.
+* `#!yaml generate`, where your `#!css script` generates the list of labels that should be added to the Merge Request.
 
     The [`#!css script`](#label.script) must return a `list of strings`, where each label returned will be added to the Merge Request.
 
@@ -153,11 +186,11 @@ Thanks to the dynamic nature of the `#!yaml generate` strategy, it has fantastic
 
 ### `label[].name` {#label.name data-toc-label="name"}
 
-- When using `#!yaml label.strategy: conditional`
+* When using `#!yaml label.strategy: conditional`
 
     **REQUIRED** The `#!css name` of the label to create.
 
-- When using `#!yaml label.strategy: generate`
+* When using `#!yaml label.strategy: generate`
 
     **OMITTED** The `#!css name` field must not be set when using the `#!yaml generate` strategy.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,19 +47,37 @@ A list of emails that should be ignored when considering user activity. Default:
     * `scm-engine` will read all files from a project in a single request where possible; up to 100 files are supported.
     * `scm-engine` do NOT cache any remote configuration files; they are always read during evaluation cycle.
 
+!!! example "Example 'include' configuration loading 4 files from the 'platform/scm-engine-library' project"
+
+    ```yaml
+    include:
+      - project: platform/scm-engine-library
+        files:
+          - label/change-type.yml
+          - label/last-commit-age.yml
+          - label/need-rebase.yml
+          - life-cycle/close-merge-request-3-weeks.yml
+
+      label:
+        - ....
+
+      actions:
+        - ...
+    ```
+
 ### `include[].project` {#include.project data-toc-label="project"}
 
 The GitLab repository slug to read configuration files, like `example/project`.
+
+### `include[].files` {#include.files data-toc-label="files"}
+
+The list of files to include from the project. The paths must be *relative* to the repository root, e.x. `label/some-config-file.yml`; NOT `/label/some-config-file.yml`
 
 ### `include[].ref` {#include.ref data-toc-label="ref"}
 
 Optional Git reference to read the configuration from; it can be a tag, branch, or commit SHA.
 
 If omitted, `HEAD` is used; meaning your default branch.
-
-### `include[].files` {#include.files data-toc-label="files"}
-
-The list of files to include from the project. The paths must be *relative* to the repository root, e.x. `label/some-config-file.yml`; NOT `/label/some-config-file.yml`
 
 ## `actions[]` {#actions data-toc-label="actions"}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/jippi/scm-engine/pkg/scm"
 	slogctx "github.com/veqryn/slog-context"
 )
 
 type Config struct {
 	DryRun             *bool              `yaml:"dry_run"`
-	Labels             Labels             `yaml:"label"`
 	Actions            Actions            `yaml:"actions"`
 	IgnoreActivityFrom IgnoreActivityFrom `yaml:"ignore_activity_from"`
+	Includes           []Include          `yaml:"include"`
+	Labels             Labels             `yaml:"label"`
 }
 
 func (c Config) Evaluate(ctx context.Context, evalContext scm.EvalContext) ([]scm.EvaluationResult, []Action, error) {
@@ -31,4 +33,22 @@ func (c Config) Evaluate(ctx context.Context, evalContext scm.EvalContext) ([]sc
 	}
 
 	return labels, actions, nil
+}
+
+func (c *Config) LoadIncludes(ctx context.Context, client scm.Client) error {
+	// No files to include
+	if len(c.Includes) == 0 {
+		return nil
+	}
+
+	for _, include := range c.Includes {
+		blobs, err := client.GetProjectFiles(ctx, include.Project, include.Ref, include.Files)
+		if err != nil {
+			return fmt.Errorf("failed to load included config files from project [%s]: %w", include.Project, err)
+		}
+
+		spew.Dump(blobs)
+	}
+
+	return nil
 }

--- a/pkg/config/include.go
+++ b/pkg/config/include.go
@@ -1,0 +1,7 @@
+package config
+
+type Include struct {
+	Project string   `yaml:"project"`
+	Ref     *string  `yaml:"ref"`
+	Files   []string `yaml:"files"`
+}

--- a/pkg/scm/github/client.go
+++ b/pkg/scm/github/client.go
@@ -68,3 +68,8 @@ func (client *Client) Start(ctx context.Context) error {
 func (client *Client) Stop(ctx context.Context, err error) error {
 	return nil
 }
+
+// Get Project Files
+func (client *Client) GetProjectFiles(ctx context.Context, project string, ref *string, files []string) (map[string]string, error) {
+	return nil, errors.New("not implemented yet")
+}

--- a/pkg/scm/interfaces.go
+++ b/pkg/scm/interfaces.go
@@ -9,6 +9,7 @@ type Client interface {
 	ApplyStep(ctx context.Context, evalContext EvalContext, update *UpdateMergeRequestOptions, step EvaluationActionStep) error
 	EvalContext(ctx context.Context) (EvalContext, error)
 	FindMergeRequestsForPeriodicEvaluation(ctx context.Context, filters MergeRequestListFilters) ([]PeriodicEvaluationMergeRequest, error)
+	GetProjectFiles(ctx context.Context, project string, ref *string, files []string) (map[string]string, error)
 	Labels() LabelClient
 	MergeRequests() MergeRequestClient
 	Start(ctx context.Context) error
@@ -30,9 +31,9 @@ type MergeRequestClient interface {
 type EvalContext interface {
 	CanUseConfigurationFileFromChangeRequest(ctx context.Context) bool
 	GetDescription() string
+	HasExecutedActionGroup(name string) bool
 	IsValid() bool
 	SetContext(ctx context.Context)
 	SetWebhookEvent(in any)
 	TrackActionGroupExecution(name string)
-	HasExecutedActionGroup(name string) bool
 }


### PR DESCRIPTION
### Implementation

* Each `include` block references a GitLab project name and the list of files to be included.
* We use GraphQL to do a single read for _all_ the config files in a single repository (so reading ten files is still only 1 GraphQL request to GitLab).
* We support up to 100 include files; which is the limit of GraphQL nodes to return for a `blob` node)
* We require all remote files to exist; it's a hard failure if they do not.
* We require all remote files to be valid; it's a hard failure if they are not.
* We only ever `append` remote configuration onto the local configuration; there is no support for merging/replacing existing configurations. `scm-engine` does not have a notion of `identifiers`.
* Certain configuration settings are NoOp/ignored; those emit a warning log for easier debugging of this issue
* We do not cache any remote includes; every evaluation will re-read the files from the source
* We *do* support pinning remote includes to a specific `ref` (sha/branch/tag); those are not cached either 

### Example config

```yaml
include:
  - project: platform/scm-engine-library
    files:
      - label/change-type.yml
      - label/last-commit-age.yml
      - label/need-rebase.yml
      - life-cycle/close-merge-request-3-weeks.yml
```