### PR TITLE
fix: allow CI pipeline to fail if the Change Request changes scm-engine configuration file

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	slogctx "github.com/veqryn/slog-context"
 )
 
-// nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var (
 	commit  = "unknown"
 	date    = "unknown"

--- a/pkg/scm/github/client.go
+++ b/pkg/scm/github/client.go
@@ -65,7 +65,7 @@ func (client *Client) Start(ctx context.Context) error {
 }
 
 // Stop pipeline
-func (client *Client) Stop(ctx context.Context, err error) error {
+func (client *Client) Stop(ctx context.Context, err error, allowPipelineFailure bool) error {
 	return nil
 }
 

--- a/pkg/scm/github/context.go
+++ b/pkg/scm/github/context.go
@@ -109,3 +109,7 @@ func (c *Context) HasExecutedActionGroup(name string) bool {
 
 	return ok
 }
+
+func (c *Context) AllowPipelineFailure(ctx context.Context) bool {
+	return len(c.PullRequest.findModifiedFiles(state.ConfigFilePath(ctx))) == 1
+}

--- a/pkg/scm/gitlab/client.go
+++ b/pkg/scm/gitlab/client.go
@@ -185,7 +185,7 @@ func (client *Client) Start(ctx context.Context) error {
 }
 
 // Stop pipeline
-func (client *Client) Stop(ctx context.Context, evalError error) error {
+func (client *Client) Stop(ctx context.Context, evalError error, allowPipelineFailure bool) error {
 	ok, pattern := state.ShouldUpdatePipeline(ctx)
 	if !ok {
 		return nil
@@ -210,7 +210,10 @@ func (client *Client) Stop(ctx context.Context, evalError error) error {
 	)
 
 	if evalError != nil {
-		status = go_gitlab.Success
+		if allowPipelineFailure {
+			status = go_gitlab.Failed
+		}
+
 		message = evalError.Error()
 	}
 

--- a/pkg/scm/gitlab/context.go
+++ b/pkg/scm/gitlab/context.go
@@ -130,6 +130,15 @@ func (c *Context) CanUseConfigurationFileFromChangeRequest(ctx context.Context) 
 	return true
 }
 
+// AllowPipelineFailure controls if the CI pipeline are allowed to fail
+//
+// We allow the pipeline to fail with an error if the SCM-Engine configuration file
+// is changed within the merge request, effectively allowing us to lint the configuration
+// file when changing it but failing "open" in all other cases.
+func (c *Context) AllowPipelineFailure(ctx context.Context) bool {
+	return len(c.MergeRequest.findModifiedFiles(state.ConfigFilePath(ctx))) == 1
+}
+
 func (c *Context) TrackActionGroupExecution(group string) {
 	// Ungrouped actions shouldn't be tracked
 	if len(group) == 0 {

--- a/pkg/scm/interfaces.go
+++ b/pkg/scm/interfaces.go
@@ -13,7 +13,7 @@ type Client interface {
 	Labels() LabelClient
 	MergeRequests() MergeRequestClient
 	Start(ctx context.Context) error
-	Stop(ctx context.Context, err error) error
+	Stop(ctx context.Context, err error, allowPipelineFailure bool) error
 }
 
 type LabelClient interface {
@@ -29,6 +29,7 @@ type MergeRequestClient interface {
 }
 
 type EvalContext interface {
+	AllowPipelineFailure(ctx context.Context) bool
 	CanUseConfigurationFileFromChangeRequest(ctx context.Context) bool
 	GetDescription() string
 	HasExecutedActionGroup(name string) bool

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -156,10 +156,10 @@ func MergeRequestIDInt(ctx context.Context) int {
 func MergeRequestIDUint(ctx context.Context) uint64 {
 	val := MergeRequestID(ctx)
 
-	number, err := strconv.Atoi(val)
+	number, err := strconv.ParseUint(val, 10, 64)
 	if err != nil {
 		panic(err)
 	}
 
-	return uint64(number)
+	return number
 }


### PR DESCRIPTION
If the Change Request does not change the `scm-engine` configuration file, we'll continue to fail `open` by succeeding the external pipeline as today.

This should prevent scm-engine configuration changes/bugs from blocking a regular Change Request not touching SCM Engine configuration files, and still provide more visual feedback to Change Requests with bad SCM-Engine configuration 