### PR TITLE
feat: conditionally disable external CI pipeline when doing periodic evaluation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -174,14 +174,15 @@ linters-settings:
     check-return: true
     check-type-param: true
     ignore-names:
-      - tt
       - err
       - i
       - id
+      - mr
       - ok
-      - wg
       - r
+      - tt
       - w
+      - wg
 
   tagalign:
     # Align and sort can be used together or separately.

--- a/cmd/gitlab_server_periodic.go
+++ b/cmd/gitlab_server_periodic.go
@@ -83,6 +83,12 @@ func startPeriodicEvaluation(ctx context.Context, interval time.Duration, filter
 					ctx = state.WithMergeRequestID(ctx, mergeRequest.MergeRequestID)
 					ctx = state.WithProjectID(ctx, mergeRequest.Project)
 
+					if !mergeRequest.UpdatePipeline {
+						slogctx.Info(ctx, "Disabling CI pipeline commit status updating since the MR HEAD CI pipeline is in a failed state")
+
+						ctx = state.WithUpdatePipeline(ctx, false, "")
+					}
+
 					if len(mergeRequest.ConfigBlob) == 0 {
 						slogctx.Warn(ctx, "Could not find the scm-engine configuration file in the repository, skipping...")
 

--- a/pkg/scm/gitlab/client.go
+++ b/pkg/scm/gitlab/client.go
@@ -111,18 +111,18 @@ func (client *Client) FindMergeRequestsForPeriodicEvaluation(ctx context.Context
 	for _, project := range response.Projects.Nodes {
 		slogctx.Debug(ctx, fmt.Sprintf("Project %s has %d Merge Requests", project.FullPath, len(project.MergeRequests.Nodes)))
 
-		for _, mergeRequest := range project.MergeRequests.Nodes {
+		for _, mr := range project.MergeRequests.Nodes {
 			item := scm.PeriodicEvaluationMergeRequest{
 				Project:        project.FullPath,
-				MergeRequestID: mergeRequest.IID,
-				SHA:            mergeRequest.SHA,
+				MergeRequestID: mr.IID,
+				SHA:            mr.SHA,
 				UpdatePipeline: updatePipeline,
 			}
 
 			// If periodic evaluation are updating CI pipelines, check if the status of the HEAD pipeline
 			// is in a state where re-triggering the external CI pipeline would potentially send the MR creator
 			// a "Your CI pipeline failed" e-mail every time we evaluate the MR in the background (spammy!)
-			if item.UpdatePipeline && mergeRequest.HeadPipeline != nil && slices.Contains(SkipPipelineUpdateIfPeriodicAndPipelineStatusIs, mergeRequest.HeadPipeline.Status) {
+			if item.UpdatePipeline && mr.HeadPipeline != nil && slices.Contains(SkipPipelineUpdateIfPeriodicAndPipelineStatusIs, mr.HeadPipeline.Status) {
 				item.UpdatePipeline = false
 			}
 

--- a/pkg/scm/gitlab/client.go
+++ b/pkg/scm/gitlab/client.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,36 @@ import (
 )
 
 var pipelineName = scm.Ptr("scm-engine")
+
+// Skip the "update external pipeline" step if the HEAD pipeline is any
+// of the configured options
+//
+// Disable updating CI pipelines when running periodic evaluations in the background
+// to avoid sending "CI pipeline failed" notification emails to users
+//
+// If the HEAD CI pipeline for a MR is in "failed" mode and we update the external
+// pipeline, GitLab will send the user (if configured in their profile) a 'your pipeline failed'
+// email every time the background evaluation process runs.
+//
+// Possible values:
+//
+// - CANCELED
+// - CANCELING
+// - CREATED
+// - FAILED
+// - MANUAL
+// - PENDING
+// - PREPARING
+// - RUNNING
+// - SCHEDULED
+// - SKIPPED
+// - SUCCESS
+// - WAITING_FOR_CALLBACK
+// - WAITING_FOR_RESOURCE
+var SkipPipelineUpdateIfPeriodicAndPipelineStatusIs = []string{
+	"FAILED",
+	"SKIPPED",
+}
 
 // Ensure the GitLab client implements the [scm.Client]
 var _ scm.Client = (*Client)(nil)
@@ -74,14 +105,25 @@ func (client *Client) FindMergeRequestsForPeriodicEvaluation(ctx context.Context
 
 	var result []scm.PeriodicEvaluationMergeRequest
 
+	// Check if the evaluation should update CI pipelines by default
+	updatePipeline, _ := state.ShouldUpdatePipeline(ctx)
+
 	for _, project := range response.Projects.Nodes {
 		slogctx.Debug(ctx, fmt.Sprintf("Project %s has %d Merge Requests", project.FullPath, len(project.MergeRequests.Nodes)))
 
-		for _, mr := range project.MergeRequests.Nodes {
+		for _, mergeRequest := range project.MergeRequests.Nodes {
 			item := scm.PeriodicEvaluationMergeRequest{
 				Project:        project.FullPath,
-				MergeRequestID: mr.IID,
-				SHA:            mr.SHA,
+				MergeRequestID: mergeRequest.IID,
+				SHA:            mergeRequest.SHA,
+				UpdatePipeline: updatePipeline,
+			}
+
+			// If periodic evaluation are updating CI pipelines, check if the status of the HEAD pipeline
+			// is in a state where re-triggering the external CI pipeline would potentially send the MR creator
+			// a "Your CI pipeline failed" e-mail every time we evaluate the MR in the background (spammy!)
+			if item.UpdatePipeline && mergeRequest.HeadPipeline != nil && slices.Contains(SkipPipelineUpdateIfPeriodicAndPipelineStatusIs, mergeRequest.HeadPipeline.Status) {
+				item.UpdatePipeline = false
 			}
 
 			// Only set the ConfigBlob struct if the config file exists in the repository

--- a/pkg/scm/gitlab/structs.go
+++ b/pkg/scm/gitlab/structs.go
@@ -37,6 +37,10 @@ package gitlab
 //	        nodes {
 //	          iid
 //	          diffHeadSha
+//
+//	          headPipeline {
+//	            status
+//	          }
 //	        }
 //	      }
 //	    }
@@ -75,8 +79,13 @@ type PeriodicEvaluationRepository struct {
 }
 
 type PeriodicEvaluationMergeRequestNode struct {
-	IID string `graphql:"iid"`
-	SHA string `graphql:"diffHeadSha"`
+	IID          string        `graphql:"iid"`
+	SHA          string        `graphql:"diffHeadSha"`
+	HeadPipeline *PipelineNode `graphql:"headPipeline"`
+}
+
+type PipelineNode struct {
+	Status string `graphql:"status"`
 }
 
 type BlobNode struct {

--- a/pkg/scm/types.go
+++ b/pkg/scm/types.go
@@ -182,6 +182,7 @@ type PeriodicEvaluationMergeRequest struct {
 	MergeRequestID string
 	SHA            string
 	ConfigBlob     string
+	UpdatePipeline bool
 }
 
 type EvalContextualizer struct{}


### PR DESCRIPTION
Specifically when the HEAD MR CI pipeline is in a failed state, as this can trigger GitLab to send 'your CI pipeline failed' emails every time the evaluation process runs, which is undesirable